### PR TITLE
fix(connection): improve connection management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,14 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/" # Location of package.json
+  - package-ecosystem: 'npm'
+    directory: '/' # Location of package.json
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
+    groups:
+      all-dependencies:
+        patterns:
+          - '*'
     # Always increase the version requirement
     # to match the new version.
     versioning-strategy: increase

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -228,14 +228,14 @@ jobs:
         working-directory: examples/with-typescript-nextjs
         run: |
           npm i
-          npm run dev &
+          npx next dev -p 3005 &
           sleep 3
-          node_test=$(curl localhost:3003)
-          node_test2=$(curl localhost:3003/api/hello)
+          node_test=$(curl localhost:3005)
+          node_test2=$(curl localhost:3005/api/hello)
 
           if [[ $node_test == *"next.js json route"* && $node_test2 == *"{\"data\":[{\"TrackId\":1,\"Name\":\"For Those About To Rock (We Salute You)\",\"AlbumId\":1,\"MediaTypeId\":1,\"GenreId\":1,\"Composer\":\"Angus Young, Malcolm Young, Brian Johnson\",\"Milliseconds\":343719,\"Bytes\":11170334,\"UnitPrice\":0.99},{"* ]]; then
             echo "✅ node with-typescript-nextjs test passed"
-            npx kill-port 3003 -y
+            npx kill-port 3005 -y
             exit 0
           fi
           echo "❌ node with-typescript-nextjs test failed"
@@ -247,13 +247,13 @@ jobs:
           if [ "$RUNNER_OS" != "Windows" ]; then
             bun i #re-installing dependencies in windows with bash causes a panic
           fi
-          bun run dev &
+          bun next dev -p 3004 &
           sleep 3
-          bun_test=$(curl localhost:3003)
-          bun_test2=$(curl localhost:3003/api/hello)
+          bun_test=$(curl localhost:3004)
+          bun_test2=$(curl localhost:3004/api/hello)
           if [[ $bun_test == *"next.js json route"* && $bun_test2 == *"{\"data\":[{\"TrackId\":1,\"Name\":\"For Those About To Rock (We Salute You)\",\"AlbumId\":1,\"MediaTypeId\":1,\"GenreId\":1,\"Composer\":\"Angus Young, Malcolm Young, Brian Johnson\",\"Milliseconds\":343719,\"Bytes\":11170334,\"UnitPrice\":0.99},{"* ]]; then
             echo "✅ bun with-typescript-nextjs test passed"
-            npx kill-port 3003 -y
+            npx kill-port 3004 -y
             exit 0
           fi
           echo "❌ bun with-typescript-nextjs test failed"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,10 @@ on:
   push:
   workflow_dispatch:
 
+concurrency:
+  group: all
+  cancel-in-progress: true
+
 env:
   DATABASE_URL: ${{ secrets.CHINOOK_DATABASE_URL }}
 
@@ -81,7 +85,7 @@ jobs:
           node_test=$(curl localhost:3000)
           if [[ $node_test == *"{\"tracks\":[{\"TrackId\":1,\"Name\":\"For Those About To Rock (We Salute You)\",\"AlbumId\":1,\"MediaTypeId\":1,\"GenreId\":1,\"Composer\":\"Angus Young, Malcolm Young, Brian Johnson\",\"Milliseconds\":343719,\"Bytes\":11170334,\"UnitPrice\":0.99},{"* ]]; then
             echo "✅ node with-javascript-express test passed"
-            npx kill-port 3000
+            npx kill-port 3000 -y
             exit 0
           fi
           echo "❌ node with-javascript-express test failed"
@@ -98,7 +102,7 @@ jobs:
           bun_test=$(curl localhost:3000)
           if [[ $bun_test == *"{\"tracks\":[{\"TrackId\":1,\"Name\":\"For Those About To Rock (We Salute You)\",\"AlbumId\":1,\"MediaTypeId\":1,\"GenreId\":1,\"Composer\":\"Angus Young, Malcolm Young, Brian Johnson\",\"Milliseconds\":343719,\"Bytes\":11170334,\"UnitPrice\":0.99},{"* ]]; then
             echo "✅ bun with-javascript-express test passed"
-            npx kill-port 3000
+            npx kill-port 3000 -y
             exit 0
           fi
           echo "❌ bun with-javascript-express test failed"
@@ -112,7 +116,7 @@ jobs:
           deno_test=$(curl localhost:3000)
           if [[ $deno_test == *"{\"tracks\":[{\"TrackId\":1,\"Name\":\"For Those About To Rock (We Salute You)\",\"AlbumId\":1,\"MediaTypeId\":1,\"GenreId\":1,\"Composer\":\"Angus Young, Malcolm Young, Brian Johnson\",\"Milliseconds\":343719,\"Bytes\":11170334,\"UnitPrice\":0.99},{"* ]]; then
             echo "✅ deno with-javascript-express test passed"
-            npx kill-port 3000
+            npx kill-port 3000 -y
             exit 0
           fi
           echo "❌ deno with-javascript-express test failed"
@@ -231,7 +235,7 @@ jobs:
 
           if [[ $node_test == *"next.js json route"* && $node_test2 == *"{\"data\":[{\"TrackId\":1,\"Name\":\"For Those About To Rock (We Salute You)\",\"AlbumId\":1,\"MediaTypeId\":1,\"GenreId\":1,\"Composer\":\"Angus Young, Malcolm Young, Brian Johnson\",\"Milliseconds\":343719,\"Bytes\":11170334,\"UnitPrice\":0.99},{"* ]]; then
             echo "✅ node with-typescript-nextjs test passed"
-            npx kill-port 3003
+            npx kill-port 3003 -y
             exit 0
           fi
           echo "❌ node with-typescript-nextjs test failed"
@@ -249,7 +253,7 @@ jobs:
           bun_test2=$(curl localhost:3003/api/hello)
           if [[ $bun_test == *"next.js json route"* && $bun_test2 == *"{\"data\":[{\"TrackId\":1,\"Name\":\"For Those About To Rock (We Salute You)\",\"AlbumId\":1,\"MediaTypeId\":1,\"GenreId\":1,\"Composer\":\"Angus Young, Malcolm Young, Brian Johnson\",\"Milliseconds\":343719,\"Bytes\":11170334,\"UnitPrice\":0.99},{"* ]]; then
             echo "✅ bun with-typescript-nextjs test passed"
-            npx kill-port 3003
+            npx kill-port 3003 -y
             exit 0
           fi
           echo "❌ bun with-typescript-nextjs test failed"
@@ -264,7 +268,7 @@ jobs:
           deno_test=$(curl localhost:3003/api/hello)
           if [[ $deno_test == *"{\"data\":[{\"TrackId\":1,\"Name\":\"For Those About To Rock (We Salute You)\",\"AlbumId\":1,\"MediaTypeId\":1,\"GenreId\":1,\"Composer\":\"Angus Young, Malcolm Young, Brian Johnson\",\"Milliseconds\":343719,\"Bytes\":11170334,\"UnitPrice\":0.99},{"* ]]; then
             echo "✅ deno with-typescript-nextjs test passed"
-            npx kill-port 3003
+            npx kill-port 3003 -y
             exit 0
           fi
           echo "❌ deno with-typescript-nextjs test failed"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -275,6 +275,7 @@ jobs:
           exit 1
 
       - name: remove with-typescript-nextjs
+        if: matrix.os != 'ubuntu-latest' #rm: cannot remove examples/with-typescript-nextjs: Directory not empty
         run: rm -rf examples/with-typescript-nextjs
 
       - name: node with-javascript-vite

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ let database = new Database('sqlitecloud://user:password@xxx.sqlite.cloud:8860/c
 
 let name = 'Breaking The Rules'
 
-let results = await database.sql`SELECT * FROM tracks WHERE name = ${name}`
+let results = await database.sql('SELECT * FROM tracks WHERE name = ?', name)
 // => returns [{ AlbumId: 1, Name: 'Breaking The Rules', Composer: 'Angus Young... }]
 ```
 
@@ -82,7 +82,7 @@ await pubSub.listen(PUBSUB_ENTITY_TYPE.TABLE, 'albums', (error, results, data) =
   }
 })
 
-await database.sql`INSERT INTO albums (Title, ArtistId) values ('Brand new song', 1)`
+await database.sql("INSERT INTO albums (Title, ArtistId) values ('Brand new song', 1)")
 
 // Stop listening changes on the table
 await pubSub.unlisten(PUBSUB_ENTITY_TYPE.TABLE, 'albums')

--- a/examples/with-javascript-browser/index.html
+++ b/examples/with-javascript-browser/index.html
@@ -48,7 +48,7 @@
         var database = null;
 
         sendButton.addEventListener('click', () => {
-            if (!database) {
+            if (!database || !database.isConnected()) {
                 // Get the input element by ID
                 var connectionStringinputElement = document.getElementById('connectionStringInput');
                 var connectionstring = connectionStringinputElement.value;

--- a/examples/with-javascript-expo/components/AddTaskModal.js
+++ b/examples/with-javascript-expo/components/AddTaskModal.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { View, StyleSheet, Alert, Platform } from "react-native";
 import { TextInput, Button, Modal } from "react-native-paper";
 import DropdownMenu from "./DropdownMenu";
-import db from "../db/dbConnection";
+import getDbConnection from "../db/dbConnection";
 
 export default AddTaskModal = ({
   modalVisible,
@@ -30,7 +30,7 @@ export default AddTaskModal = ({
 
   const getTags = async () => {
     try {
-      const tags = await db.sql("SELECT * FROM tags");
+      const tags = await getDbConnection().sql("SELECT * FROM tags");
       setTagsList(tags);
     } catch (error) {
       console.error("Error getting tags", error);

--- a/examples/with-javascript-expo/db/dbConnection.js
+++ b/examples/with-javascript-expo/db/dbConnection.js
@@ -1,4 +1,14 @@
 import { DATABASE_URL } from "@env";
 import { Database } from "@sqlitecloud/drivers";
 
-export default db = new Database(DATABASE_URL);
+/**
+ * @type {Database}
+ */
+let database = null;
+
+export function getDbConnection() {
+    if (!database || !database.isConnected()) {
+        database = new Database(DATABASE_URL);
+    }
+    return database;
+}

--- a/examples/with-javascript-expo/db/dbConnection.js
+++ b/examples/with-javascript-expo/db/dbConnection.js
@@ -6,7 +6,7 @@ import { Database } from "@sqlitecloud/drivers";
  */
 let database = null;
 
-export function getDbConnection() {
+export default function getDbConnection() {
     if (!database || !database.isConnected()) {
         database = new Database(DATABASE_URL);
     }

--- a/examples/with-javascript-expo/hooks/useCategories.js
+++ b/examples/with-javascript-expo/hooks/useCategories.js
@@ -1,12 +1,12 @@
 import { useState, useEffect } from "react";
-import db from "../db/dbConnection";
+import getDbConnection from "../db/dbConnection";
 
 const useCategories = () => {
   const [moreCategories, setMoreCategories] = useState(["Work", "Personal"]);
 
   const getCategories = async () => {
     try {
-      const tags = await db.sql("SELECT * FROM tags");
+      const tags = await getDbConnection().sql("SELECT * FROM tags");
       const filteredTags = tags.filter((tag) => {
         return tag["name"] !== "Work" && tag["name"] !== "Personal";
       });
@@ -21,7 +21,7 @@ const useCategories = () => {
 
   const addCategory = async (newCategory) => {
     try {
-      await db.sql(
+      await getDbConnection().sql(
         "INSERT INTO tags (name) VALUES (?) RETURNING *",
         newCategory
       );
@@ -33,15 +33,15 @@ const useCategories = () => {
 
   const initializeTables = async () => {
     try {
-      const createTasksTable = await db.sql(
+      const createTasksTable = await getDbConnection().sql(
         "CREATE TABLE IF NOT EXISTS tasks (id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, isCompleted INT NOT NULL);"
       );
 
-      const createTagsTable = await db.sql(
+      const createTagsTable = await getDbConnection().sql(
         "CREATE TABLE IF NOT EXISTS tags (id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, UNIQUE(name));"
       );
 
-      const createTagsTasksTable = await db.sql(
+      const createTagsTasksTable = await getDbConnection().sql(
         "CREATE TABLE IF NOT EXISTS tasks_tags (id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, task_id INTEGER NOT NULL, tag_id INTEGER NOT NULL, FOREIGN KEY (task_id) REFERENCES tasks(id), FOREIGN KEY (tag_id) REFERENCES tags(id));"
       );
 
@@ -52,8 +52,8 @@ const useCategories = () => {
       ) {
         console.log("Successfully created tables");
 
-        await db.sql("INSERT OR IGNORE INTO tags (name) VALUES (?)", "Work");
-        await db.sql(
+        await getDbConnection().sql("INSERT OR IGNORE INTO tags (name) VALUES (?)", "Work");
+        await getDbConnection().sql(
           "INSERT OR IGNORE INTO tags (name) VALUES (?)",
           "Personal"
         );

--- a/examples/with-javascript-express/app.js
+++ b/examples/with-javascript-express/app.js
@@ -15,7 +15,7 @@ app.use(express.json())
 /* http://localhost:3001/ returns chinook tracks as json */
 app.get('/', async function (req, res, next) {
   var database = new sqlitecloud.Database(DATABASE_URL)
-  var tracks = await database.sql`USE DATABASE chinook.sqlite; SELECT * FROM tracks LIMIT 20;`
+  var tracks = await database.sql('USE DATABASE chinook.sqlite; SELECT * FROM tracks LIMIT 20;')
   res.send({ tracks })
 })
 

--- a/examples/with-javascript-vite/src/App.jsx
+++ b/examples/with-javascript-vite/src/App.jsx
@@ -1,20 +1,29 @@
 import { useEffect, useState } from "react";
 import { Database } from "@sqlitecloud/drivers";
 
-const db = new Database(import.meta.env.VITE_DATABASE_URL);
+let db = null
+
+function getDatabase() {
+  if (!db || !db.isConnected()) {
+    db = new Database("chinook.sqlite");
+  }
+
+  return db;
+}
+
 
 function App() {
   const [data, setData] = useState([]);
 
   const getAlbums = async () => {
-    const result = await db.sql`
+    const result = await getDatabase().sql(`
       USE DATABASE chinook.sqlite; 
       SELECT albums.AlbumId as id, albums.Title as title, artists.name as artist
       FROM albums 
       INNER JOIN artists 
       WHERE artists.ArtistId = albums.ArtistId
       LIMIT 20;
-    `;
+    `);
     setData(result);
   };
 

--- a/examples/with-javascript-vite/src/App.jsx
+++ b/examples/with-javascript-vite/src/App.jsx
@@ -5,7 +5,7 @@ let db = null
 
 function getDatabase() {
   if (!db || !db.isConnected()) {
-    db = new Database("chinook.sqlite");
+    db = new Database(import.meta.env.VITE_DATABASE_URL);
   }
 
   return db;

--- a/examples/with-plain-javascript/app.js
+++ b/examples/with-plain-javascript/app.js
@@ -13,7 +13,7 @@ async function selectTracks() {
   var database = new sqlitecloud.Database(DATABASE_URL)
 
   // run async query
-  var tracks = await database.sql`USE DATABASE chinook.sqlite; SELECT * FROM tracks LIMIT 20;`
+  var tracks = await database.sql('USE DATABASE chinook.sqlite; SELECT * FROM tracks LIMIT 20;')
   console.log(`selectTracks returned:`, tracks)
 
   // You can also use all the regular sqlite3 api with callbacks, see:

--- a/examples/with-typescript-nextjs/app/api/hello/route.ts
+++ b/examples/with-typescript-nextjs/app/api/hello/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest) {
   const database = new Database(DATABASE_URL)
 
   // retrieve rows from chinook database using a plain SQL query
-  const tracks = await database.sql`USE DATABASE chinook.sqlite; SELECT * FROM tracks LIMIT 20;`
+  const tracks = await database.sql('USE DATABASE chinook.sqlite; SELECT * FROM tracks LIMIT 20;')
 
   // return as json response
   return NextResponse.json<{ data: any }>({ data: tracks })

--- a/examples/with-typescript-nextjs/app/page.tsx
+++ b/examples/with-typescript-nextjs/app/page.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image'
 import styles from './page.module.css'
 
 export default function Home() {

--- a/examples/with-typescript-react-native/App.tsx
+++ b/examples/with-typescript-react-native/App.tsx
@@ -11,7 +11,7 @@ export default function App() {
       const db = new Database(`${DATABASE_URL}`);
 
       const result =
-        await db.sql`USE DATABASE chinook.sqlite; SELECT albums.AlbumId as id, albums.Title as title, artists.name as artist FROM albums INNER JOIN artists WHERE artists.ArtistId = albums.ArtistId LIMIT 20;`;
+        await db.sql('USE DATABASE chinook.sqlite; SELECT albums.AlbumId as id, albums.Title as title, artists.name as artist FROM albums INNER JOIN artists WHERE artists.ArtistId = albums.ArtistId LIMIT 20;');
 
       setAlbums(result);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sqlitecloud/drivers",
-  "version": "1.0.417",
+  "version": "1.0.421",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sqlitecloud/drivers",
-      "version": "1.0.417",
+      "version": "1.0.421",
       "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sqlitecloud/drivers",
-  "version": "1.0.421",
+  "version": "1.0.422",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sqlitecloud/drivers",
-      "version": "1.0.421",
+      "version": "1.0.422",
       "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sqlitecloud/drivers",
-  "version": "1.0.421",
+  "version": "1.0.422",
   "description": "SQLiteCloud drivers for Typescript/Javascript in edge, web and node clients",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sqlitecloud/drivers",
-  "version": "1.0.417",
+  "version": "1.0.421",
   "description": "SQLiteCloud drivers for Typescript/Javascript in edge, web and node clients",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/drivers/connection-tls.ts
+++ b/src/drivers/connection-tls.ts
@@ -250,7 +250,7 @@ export class SQLiteCloudTlsConnection extends SQLiteCloudConnection {
   }
 
   /** Disconnect immediately, release connection, no events. */
-  public close(): this {
+  close(): this {
     if (this.socket) {
       this.socket.removeAllListeners()
       this.socket.destroy()

--- a/src/drivers/connection-tls.ts
+++ b/src/drivers/connection-tls.ts
@@ -2,21 +2,21 @@
  * connection-tls.ts - connection via tls socket and sqlitecloud protocol
  */
 
-import { type SQLiteCloudConfig, SQLiteCloudError, type ErrorCallback, type ResultsCallback, SQLiteCloudCommand } from './types'
 import { SQLiteCloudConnection } from './connection'
-import { getInitializationCommands } from './utilities'
 import {
+  bufferEndsWith,
+  CMD_COMPRESSED,
+  CMD_ROWSET_CHUNK,
+  decompressBuffer,
   formatCommand,
   hasCommandLength,
   parseCommandLength,
-  popData,
-  decompressBuffer,
   parseRowsetChunks,
-  CMD_COMPRESSED,
-  CMD_ROWSET_CHUNK,
-  bufferEndsWith,
+  popData,
   ROWSET_CHUNKS_END
 } from './protocol'
+import { type ErrorCallback, type ResultsCallback, SQLiteCloudCommand, type SQLiteCloudConfig, SQLiteCloudError } from './types'
+import { getInitializationCommands } from './utilities'
 
 // explicitly importing buffer library to allow cross-platform support by replacing it
 import { Buffer } from 'buffer'
@@ -77,6 +77,10 @@ export class SQLiteCloudTlsConnection extends SQLiteCloudConnection {
         callback?.call(this, error)
       })
     })
+    this.socket.setKeepAlive(true)
+    // disable Nagle algorithm because we want our writes to be sent ASAP
+    // https://brooker.co.za/blog/2024/05/09/nagle.html
+    this.socket.setNoDelay(true)
 
     this.socket.on('data', data => {
       this.processCommandsData(data)
@@ -95,6 +99,11 @@ export class SQLiteCloudTlsConnection extends SQLiteCloudConnection {
     this.socket.on('close', () => {
       this.close()
       this.processCommandsFinish(new SQLiteCloudError('Connection closed', { errorCode: 'ERR_CONNECTION_CLOSED' }))
+    })
+
+    this.socket.on('timeout', () => {
+      this.close()
+      this.processCommandsFinish(new SQLiteCloudError('Connection ened due to timeout', { errorCode: 'ERR_CONNECTION_TIMEOUT' }))
     })
 
     return this
@@ -241,7 +250,7 @@ export class SQLiteCloudTlsConnection extends SQLiteCloudConnection {
   }
 
   /** Disconnect immediately, release connection, no events. */
-  close(): this {
+  public close(): this {
     if (this.socket) {
       this.socket.removeAllListeners()
       this.socket.destroy()

--- a/src/drivers/connection-ws.ts
+++ b/src/drivers/connection-ws.ts
@@ -39,7 +39,7 @@ export class SQLiteCloudWebsocketConnection extends SQLiteCloudConnection {
 
         this.socket.on('disconnect', (reason) => {
           this.close()
-          callback?.call(this, new SQLiteCloudError('Disconnected', { errorCode: 'ERR_CONNECTION_DISCONNECTED', cause: reason }))
+          callback?.call(this, new SQLiteCloudError('Disconnected', { errorCode: 'ERR_CONNECTION_ENDED', cause: reason }))
         })
 
         this.socket.on('error', (error: Error) => {

--- a/src/drivers/pubsub.ts
+++ b/src/drivers/pubsub.ts
@@ -77,14 +77,14 @@ export class PubSub {
    * @param name Channel name
    */
   public async removeChannel(name: string): Promise<any> {
-    return this.connection.sql(`REMOVE CHANNEL ?;`, name)
+    return this.connection.sql('REMOVE CHANNEL ?;', name)
   }
 
   /**
    * Send a message to the channel.
    */
   public notifyChannel(channelName: string, message: string): Promise<any> {
-    return this.connection.sql`NOTIFY ${channelName} ${message};`
+    return this.connection.sql('NOTIFY ? ?;', channelName, message)
   }
 
   /**

--- a/test/connection-tls.test.ts
+++ b/test/connection-tls.test.ts
@@ -60,10 +60,9 @@ it(
     const connection = new SQLiteCloudTlsConnection(configObj, error => {
       expect(error).toBeNull()
       expect(connection.connected).toBe(true)
-      done()
       connection.close()
+      done()
     })
-    expect(connection).toBeDefined()
   },
   LONG_TIMEOUT
 )
@@ -82,7 +81,6 @@ it(
           done()
         })
       })
-      expect(connection).toBeDefined()
     },
     LONG_TIMEOUT
   )
@@ -103,7 +101,6 @@ it(
             done()
           })
         })
-        expect(connection).toBeDefined()
       } catch (error) {
         console.error(`An error occurred while connecting using api key: ${error}`)
         debugger
@@ -142,7 +139,6 @@ it(
         }
       })
     })
-    expect(connection).toBeDefined()
   })
 
   it('should connect with insecure connection string', done => {

--- a/test/connection-tls.test.ts
+++ b/test/connection-tls.test.ts
@@ -53,8 +53,23 @@ describe('connect', () => {
   })
 */
 
+it(
+  'should connect with config object string',
+  done => {
+    const configObj = getChinookConfig()
+    const connection = new SQLiteCloudTlsConnection(configObj, error => {
+      expect(error).toBeNull()
+      expect(connection.connected).toBe(true)
+      done()
+      connection.close()
+    })
+    expect(connection).toBeDefined()
+  },
+  LONG_TIMEOUT
+)
+
   it(
-    'should connect with config object string',
+    'should connect with config object string and test command',
     done => {
       const configObj = getChinookConfig()
       const connection = new SQLiteCloudTlsConnection(configObj, error => {

--- a/test/connection-ws.test.ts
+++ b/test/connection-ws.test.ts
@@ -41,8 +41,8 @@ describe('connection-ws', () => {
       connection = new SQLiteCloudWebsocketConnection(configObj, error => {
         expect(error).toBeNull()
         done()
+        connection?.close()
       })
-      connection?.close()
     })
 
     it('should not connect with incorrect credentials', done => {
@@ -55,8 +55,8 @@ describe('connection-ws', () => {
       const connection = new SQLiteCloudWebsocketConnection(configObj, error => {
         expect(error).toBeDefined()
         done()
+        connection?.close()
       })
-      connection?.close()
     })
     /* TODO RESTORE TEST
     it('should connect with connection string', done => {

--- a/test/connection-ws.test.ts
+++ b/test/connection-ws.test.ts
@@ -40,8 +40,8 @@ describe('connection-ws', () => {
       let connection: SQLiteCloudWebsocketConnection | null = null
       connection = new SQLiteCloudWebsocketConnection(configObj, error => {
         expect(error).toBeNull()
-        done()
         connection?.close()
+        done()
       })
     })
 

--- a/test/pubsub.test.ts
+++ b/test/pubsub.test.ts
@@ -191,7 +191,7 @@ describe('pubSub', () => {
 
           await pubSub.setPubSubOnly()
 
-          expect(connection.sql`SELECT 1`).rejects.toThrow('Connection not established')
+          expect(connection.sql`SELECT 1`).rejects.toThrow('Connection unavailable. Maybe it got disconnected?')
           expect(pubSub.connected()).toBeTruthy()
 
           await connection2.sql`UPDATE genres SET Name = ${newName} WHERE GenreId = 1`


### PR DESCRIPTION
- resolve the creation of two connections. The dynamic import of the connection modules delayed the initialization of the SQLiteCloudConnection object. Between the initialization of the Database object and the call to sql() method, the connection was not yet initialized
- connection to the database and the commands are put in queue to ensure the connection to be ready (the socket connection is a background operation)
- remove the implicit connection to the database in the sql() methods. We want the user be aware of the status of the connection (eg, due to open transactions)
- enable TCP keep alive to be notified of the most of the cases of errors on the TCP socket
