### PR TITLE
feat(jest): use a new jest custom reporter that provides verbose test output while suppressing console logs for passing test.

### DIFF
--- a/jest-custom-reporter.js
+++ b/jest-custom-reporter.js
@@ -1,0 +1,70 @@
+/**
+ * Custom Jest reporter that provides verbose test output with colors
+ * while suppressing console logs for passing tests. Only shows console
+ * output (like console.error) for failed tests.
+ */
+
+const { DefaultReporter } = require('@jest/reporters')
+const chalk = require('chalk')
+
+class Reporter extends DefaultReporter {
+  constructor(globalConfig, options) {
+    super(globalConfig, options)
+  }
+
+  printTestFileHeader(testPath, config, result) {
+    // Don't call super to avoid printing console output
+    const testFileName = testPath.replace(process.cwd() + '/', '')
+    const duration = result.perfStats ? ((result.perfStats.end - result.perfStats.start) / 1000).toFixed(3) : '0.000'
+    const status = result.numFailingTests === 0 ? chalk.green('PASS') : chalk.red('FAIL')
+
+    this.log(`${status}  ${testFileName} ${chalk.gray(`(${duration} s)`)}`)
+
+    // Print test structure
+    const testsByGroup = {}
+    result.testResults.forEach(test => {
+      const groupName = test.ancestorTitles[0] || 'Root'
+      if (!testsByGroup[groupName]) {
+        testsByGroup[groupName] = []
+      }
+      testsByGroup[groupName].push(test)
+    })
+
+    Object.entries(testsByGroup).forEach(([groupName, tests]) => {
+      if (groupName !== 'Root') {
+        this.log(`  ${groupName}`)
+      }
+      tests.forEach(test => {
+        const prefix = groupName !== 'Root' ? '    ' : '  '
+        const status = test.status === 'passed' ? chalk.green('✓') : chalk.red('✗')
+        const duration = test.duration ? chalk.gray(` (${test.duration} ms)`) : ''
+        this.log(`${prefix}${status} ${test.title}${duration}`)
+      })
+    })
+
+    // Show console output only for failed tests
+    if (result.numFailingTests > 0 && result.console && result.console.length > 0) {
+      result.console.forEach(entry => {
+        this.log(`  ${entry.type}`)
+        this.log(`    ${entry.message}`)
+      })
+    }
+  }
+
+  onRunComplete(contexts, results) {
+    this.log('')
+    const passedSuites = chalk.green(`${results.numPassedTestSuites} passed`)
+    const failedSuites = results.numFailedTestSuites > 0 ? `, ${chalk.red(`${results.numFailedTestSuites} failed`)}` : ''
+    this.log(`Test Suites: ${passedSuites}${failedSuites}, ${results.numTotalTestSuites} total`)
+
+    const passedTests = chalk.green(`${results.numPassedTests} passed`)
+    const failedTests = results.numFailedTests > 0 ? `, ${chalk.red(`${results.numFailedTests} failed`)}` : ''
+    this.log(`Tests:       ${passedTests}${failedTests}, ${results.numTotalTests} total`)
+
+    this.log(`Snapshots:   ${results.snapshot.total} total`)
+    const duration = results.testRuntimeSummary ? (results.testRuntimeSummary.slow / 1000).toFixed(1) : '0.0'
+    this.log(`Time:        ${duration} s`)
+  }
+}
+
+module.exports = Reporter

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,9 +13,8 @@ module.exports = {
       }
     ]
   },
-  // Other Jest configuration options
   reporters: [
-    'default',
+    './jest-custom-reporter.js',
     [
       'jest-html-reporter',
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sqlitecloud/drivers",
-  "version": "1.0.574",
+  "version": "1.0.611",
   "description": "SQLiteCloud drivers for Typescript/Javascript in edge, web and node clients",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
... Only shows console output (like console.error) for failed tests.

<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
