### PR TITLE
Fix/test speed avoid debug level

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sqlitecloud/drivers",
-  "version": "1.0.621",
+  "version": "1.0.626",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sqlitecloud/drivers",
-      "version": "1.0.621",
+      "version": "1.0.626",
       "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sqlitecloud/drivers",
-  "version": "1.0.613",
+  "version": "1.0.621",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sqlitecloud/drivers",
-      "version": "1.0.613",
+      "version": "1.0.621",
       "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sqlitecloud/drivers",
-  "version": "1.0.621",
+  "version": "1.0.626",
   "description": "SQLiteCloud drivers for Typescript/Javascript in edge, web and node clients",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/test/database.test.ts
+++ b/test/database.test.ts
@@ -575,12 +575,12 @@ describe('Database.sql (async)', () => {
       const databaseNameInjectSQL = `${databaseName}; SELECT * FROM people`
       await expect(database.sql`USE DATABASE ${databaseNameInjectSQL}`).rejects.toThrow(`Database name contains invalid characters (${databaseNameInjectSQL}).`)
 
-      let key = 'log_level'
-      let value = 'debug'
+      let key = 'test_key'
+      let value = 'test_value'
       await expect(database.sql`SET KEY ${key} TO ${value}`).resolves.toBe('OK')
 
-      key = 'log_level'
-      value = 'debug; DROP TABLE people'
+      key = 'test_key'
+      value = 'test_value; DROP TABLE people'
       await expect(database.sql`SET KEY ${key} TO ${value}`).resolves.toBe('OK')
       const result = await database.sql`SELECT * FROM people`
       expect(result.length).toBeGreaterThan(0)


### PR DESCRIPTION
Improve test speed by avoiding debug log level

### Description of change

The `should commands accept bindings` test from `database.test.ts` was incorrectly using the `SET KEY log_level TO debug` command.

In an earlier commit ([chore(test): fix a typo in the database test](https://github.com/sqlitecloud/sqlitecloud-js/commit/69ec5425fbfed1e64aa211612410f0f421dce477)), I mistakenly treated the absence of log_level as a typo. In reality, the test was intentionally written not to modify the log level.

This change restores the intended behavior and makes it explicit that the test must avoid changing the log level, since doing so can cause subsequent tests to run much more slowly.

### Pull-Request Checklist

- [ ] Code is up-to-date with the `main` branch
- [ ] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)
